### PR TITLE
PR 1

### DIFF
--- a/Forno.cpp
+++ b/Forno.cpp
@@ -3,53 +3,30 @@
 
 // Costruttore
 Forno::Forno(double tassoRiscaldamento, double tassoRaffreddamento)
-    : temperatura(0.0), tassoRiscaldamento(tassoRiscaldamento), tassoRaffreddamento(tassoRaffreddamento) {
-        stato = SPENTO;
-    }
+    , _tassoRiscaldamento(tassoRiscaldamento)
+    , _tassoRaffreddamento(tassoRaffreddamento) {}
 
-
-void Forno::aggiorna(){
-
-    if (stato == ACCESO)
-    {
-        
+void Forno::aggiorna() {
+    if (stato == ACCESO) {
         // Simulo un aumento di temperatura basato su una funzione logistica. Il riscaldamento è legato alla potenza impostata del forno.
-        riscaldamento = 100.0 * potenzaPercentuale * (1 - exp(-tassoRiscaldamento * millis() / 1000.0));
+        _riscaldamento = 100.0 * _potenzaPercentuale * (1 - exp(-_tassoRiscaldamento * millis() / 1000.0));
     }
-    
-
     // Simulo il raffreddamento con una funzione logistica. Il raffreddamento è legato alla temperatura. Maggiore temperatura significa maggior raffreddamento
-    raffreddamento = 100.0 * exp(-tassoRaffreddamento * millis() / 1000.0)* (temperatura / 100.0);
-    
-    
-    temperatura = riscaldamento - raffreddamento;
+    _raffreddamento = 100.0 * exp(-_tassoRaffreddamento * millis() / 1000.0)* (_temperatura / 100.0);
+    _temperatura = _riscaldamento - _raffreddamento;
 
     //clippo valori di uscita tra 20°C e 300°C
-    if (temperatura > 300.0) {
-        temperatura = 300.0;
-    }
-
-    if (temperatura < 20.0) {
-        temperatura = 20.0;
-    }
+    _temperatura = (_temperatura > 300.0) ? 300.0 : _temperatura;
+    _temperatura = (_temperatura < 20.0) ? 20.0 : _temperatura;
 }
 
-void Forno::impostaStato(statoForno nuovoStato){
-    stato = nuovoStato;
+void Forno::accendi() { _stato = ACCESO; }
+void Forno::spento() { _stato = SPENTO; }
+
+Forno::statoForno Forno::stato() { return _stato; }
+
+void Forno::impostaPotenzaPercentuale(double potenza) {
+    _potenzaPercentuale = fmin(fmax(_potenza, 0.0), 100.0) / 100.0;
 }
 
-Forno::statoForno Forno::ottieniStato(){
-    return stato;
-}
-
-
-void Forno::impostaPotenzaPercentuale(double potenza){
-    // Clippo la potenza in modo che sia compresa tra 0 e 100
-    potenzaPercentuale = fmin(fmax(potenza, 0.0), 100.0) / 100.0;
-    
-}
-
-double Forno::ottieniTemperatura() {
-    // Funzione per ottenere la temperatura attuale del forno
-    return temperatura;
-}
+double Forno::temperatura() { return _temperatura; }

--- a/Forno.cpp
+++ b/Forno.cpp
@@ -12,7 +12,7 @@ void Forno::aggiorna() {
         _riscaldamento = 100.0 * _potenzaPercentuale * (1 - exp(-_tassoRiscaldamento * millis() / 1000.0));
     }
     // Simulo il raffreddamento con una funzione logistica. Il raffreddamento è legato alla temperatura. Maggiore temperatura significa maggior raffreddamento
-    _raffreddamento = 100.0 * exp(-_tassoRaffreddamento * millis() / 1000.0)* (_temperatura / 100.0);
+    _raffreddamento = 100.0 * exp(-_tassoRaffreddamento * millis() / 1000.0) * (_temperatura / 100.0);
     _temperatura = _riscaldamento - _raffreddamento;
 
     //clippo valori di uscita tra 20°C e 300°C
@@ -23,7 +23,7 @@ void Forno::aggiorna() {
 void Forno::accendi() { _stato = ACCESO; }
 void Forno::spento() { _stato = SPENTO; }
 
-Forno::statoForno Forno::stato() { return _stato; }
+Stato Forno::stato() { return _stato; }
 
 void Forno::impostaPotenzaPercentuale(double potenza) {
     _potenzaPercentuale = fmin(fmax(_potenza, 0.0), 100.0) / 100.0;

--- a/Forno.cpp
+++ b/Forno.cpp
@@ -23,7 +23,7 @@ void Forno::aggiorna() {
 void Forno::accendi() { _stato = ACCESO; }
 void Forno::spento() { _stato = SPENTO; }
 
-Stato Forno::stato() { return _stato; }
+bool Forno::stato() { return _stato == ACCESO; }
 
 void Forno::impostaPotenzaPercentuale(double potenza) {
     _potenzaPercentuale = fmin(fmax(_potenza, 0.0), 100.0) / 100.0;

--- a/Forno.cpp
+++ b/Forno.cpp
@@ -1,4 +1,4 @@
-#include "forno.h"
+#include "Forno.h"
 
 
 // Costruttore

--- a/Forno.cpp
+++ b/Forno.cpp
@@ -16,8 +16,8 @@ void Forno::aggiorna() {
     _temperatura = _riscaldamento - _raffreddamento;
 
     //clippo valori di uscita tra 20°C e 300°C
-    _temperatura = (_temperatura > 300.0) ? 300.0 : _temperatura;
-    _temperatura = (_temperatura < 20.0) ? 20.0 : _temperatura;
+    _temperatura = (_temperatura > _max_temp) ? _max_temp : _temperatura;
+    _temperatura = (_temperatura < _min_temp) ? _min_temp : _temperatura;
 }
 
 void Forno::accendi() { _stato = ACCESO; }

--- a/Forno.h
+++ b/Forno.h
@@ -10,12 +10,12 @@
 
 #include "Arduino.h"
 
-enum Stato {
-    SPENTO,
-    ACCESO
-};
-
 class Forno {
+    enum Stato {
+        SPENTO,
+        ACCESO
+    };
+
     const double _max_temp = 300.0;
     const double _min_temp = 20.0;
     double _temperatura = 20.0;
@@ -30,7 +30,7 @@ public:
     Forno(double tassoRiscaldamento, double tassoRaffreddamento);  // costruttore
     void aggiorna();                                               // aggiorna la temperatura del forno
     double temperatura();                                          // metodo per ottenere la temperatura attuale del forno
-    Stato stato();                                                 // metodo per ottenere lo stato (acceso/spento) del forno
+    bool acceso();                                                 // metodo che informa se il forno e' acceso
     void accendi();                                                // metodo per accendere il forno
     void spegni();                                                 // metodo per spegnere il forno
     void impostaPotenzaPercentuale(double potenza);                // metodo che imposta la potenza di riscaldamento del forno

--- a/Forno.h
+++ b/Forno.h
@@ -1,41 +1,35 @@
-/*
-Oggetto forno per simulare funzionamento fisico di riscaldamento/raffreddamento. E' molto semplificato. Servirà per fare due test
-con un PID.
-Il forno si scalda se acceso e se viene settata una potenza diversa (maggiore) a zero.
-Indipendentemente che sia attivo il riscaldamento o meno, il forno subisce anche un fenomeno di raffreddamento. 
-La funzione aggiorna() si occupa di modificare la temperatura del forno. 
+/**
+ * Oggetto forno per simulare funzionamento fisico di riscaldamento/raffreddamento. E' molto semplificato. Servirà per fare due test
+ * con un PID.
+ * Il forno si scalda se acceso e se viene settata una potenza diversa (maggiore) a zero.
+ * Indipendentemente che sia attivo il riscaldamento o meno, il forno subisce anche un fenomeno di raffreddamento. 
+ * La funzione aggiorna() si occupa di modificare la temperatura del forno. 
+ */ 
 
-*/ 
+#pragma once
 
-#ifndef FORNO_H
-#define FORNO_H
 #include "Arduino.h"
 
 class Forno {
-    //attenzione. La struttura dell'enum va dichiarata prima di dichiarare una variabile di questo tipo, altrimenti giustamente impazzisce.
-    public:
-        enum statoForno {
-            ACCESO,
-            SPENTO
-        };
+    enum statoForno {
+        SPENTO,
+        ACCESO
+    };
 
-    private:
-        double temperatura;
-        double potenzaPercentuale;  //potenza del forno settata (in futuro dinamicamente dal PID)
-        double riscaldamento;       //variazione temperatura causata dall'azione di riscaldamento
-        double raffreddamento;      // variazione temperatura causata dall'azione di raffreddamento
-        double tassoRiscaldamento;  //una caratteristica del forno, un k che definisce il tasso di riscaldamento. 
-        double tassoRaffreddamento; //una caratteristica del forno, un k che definisce il tasso di raffreddamento. 
-        statoForno stato;           // enum, acceso o spento
+    double _temperatura;
+    double _potenzaPercentuale;  //potenza del forno settata (in futuro dinamicamente dal PID)
+    double _riscaldamento;       //variazione temperatura causata dall'azione di riscaldamento
+    double _raffreddamento;      // variazione temperatura causata dall'azione di raffreddamento
+    double _tassoRiscaldamento;  //una caratteristica del forno, un k che definisce il tasso di riscaldamento. 
+    double _tassoRaffreddamento; //una caratteristica del forno, un k che definisce il tasso di raffreddamento. 
+    statoForno _stato = SPENTO;  // enum, acceso o spento
 
-    public:
-        Forno( double tassoRiscaldamento, double tassoRaffreddamento );  //costruttore
-        void aggiorna();  //aggiorna la temperatura del forno
-        double ottieniTemperatura();  //funzione che restituisce la temperatura attuale del forno
-        statoForno ottieniStato(); //funzione che restituisce lo stato (acceso/spento) del forno
-        void impostaStato(statoForno nuovoStato); //funzione per settare lo stato (acceso/spento) del forno
-        void impostaPotenzaPercentuale(double potenza); //fuznione che imposta la potenza di riscaldamento del forno
-        
+public:
+    Forno( double tassoRiscaldamento, double tassoRaffreddamento );  // costruttore
+    void aggiorna();                                                 // aggiorna la temperatura del forno
+    double temperatura();                                            // funzione che restituisce la temperatura attuale del forno
+    statoForno stato();                                              // funzione che restituisce lo stato (acceso/spento) del forno
+    void accendi();                                                  // metodo per accendere il forno
+    void spegni();                                                   // metodo per spegnere il forno
+    void impostaPotenzaPercentuale(double potenza);                  // metodo che imposta la potenza di riscaldamento del forno
 };
-
-#endif  // FORNO_H

--- a/Forno.h
+++ b/Forno.h
@@ -10,29 +10,28 @@
 
 #include "Arduino.h"
 
-enum statoForno {
+enum Stato {
     SPENTO,
     ACCESO
 };
 
-
 class Forno {
-    const _max_temp = 300.0;
-    const _min_temp = 20.0;
-    double _temperatura = 0.0;
-    double _potenzaPercentuale;  //potenza del forno settata (in futuro dinamicamente dal PID)
-    double _riscaldamento;       //variazione temperatura causata dall'azione di riscaldamento
+    const double _max_temp = 300.0;
+    const double _min_temp = 20.0;
+    double _temperatura = 20.0;
+    double _potenzaPercentuale;  // potenza del forno settata (in futuro dinamicamente dal PID)
+    double _riscaldamento;       // variazione temperatura causata dall'azione di riscaldamento
     double _raffreddamento;      // variazione temperatura causata dall'azione di raffreddamento
-    double _tassoRiscaldamento;  //una caratteristica del forno, un k che definisce il tasso di riscaldamento. 
-    double _tassoRaffreddamento; //una caratteristica del forno, un k che definisce il tasso di raffreddamento. 
-    statoForno _stato = SPENTO;  // enum, acceso o spento
+    double _tassoRiscaldamento;  // una caratteristica del forno, un k che definisce il tasso di riscaldamento. 
+    double _tassoRaffreddamento; // una caratteristica del forno, un k che definisce il tasso di raffreddamento. 
+    Stato  _stato = SPENTO;      // enum, acceso o spento
 
 public:
-    Forno( double tassoRiscaldamento, double tassoRaffreddamento );  // costruttore
-    void aggiorna();                                                 // aggiorna la temperatura del forno
-    double temperatura();                                            // funzione che restituisce la temperatura attuale del forno
-    statoForno stato();                                              // funzione che restituisce lo stato (acceso/spento) del forno
-    void accendi();                                                  // metodo per accendere il forno
-    void spegni();                                                   // metodo per spegnere il forno
-    void impostaPotenzaPercentuale(double potenza);                  // metodo che imposta la potenza di riscaldamento del forno
+    Forno(double tassoRiscaldamento, double tassoRaffreddamento);  // costruttore
+    void aggiorna();                                               // aggiorna la temperatura del forno
+    double temperatura();                                          // metodo per ottenere la temperatura attuale del forno
+    Stato stato();                                                 // metodo per ottenere lo stato (acceso/spento) del forno
+    void accendi();                                                // metodo per accendere il forno
+    void spegni();                                                 // metodo per spegnere il forno
+    void impostaPotenzaPercentuale(double potenza);                // metodo che imposta la potenza di riscaldamento del forno
 };

--- a/Forno.h
+++ b/Forno.h
@@ -10,13 +10,16 @@
 
 #include "Arduino.h"
 
-class Forno {
-    enum statoForno {
-        SPENTO,
-        ACCESO
-    };
+enum statoForno {
+    SPENTO,
+    ACCESO
+};
 
-    double _temperatura;
+
+class Forno {
+    const _max_temp = 300.0;
+    const _min_temp = 20.0;
+    double _temperatura = 0.0;
     double _potenzaPercentuale;  //potenza del forno settata (in futuro dinamicamente dal PID)
     double _riscaldamento;       //variazione temperatura causata dall'azione di riscaldamento
     double _raffreddamento;      // variazione temperatura causata dall'azione di raffreddamento

--- a/TestPIDAutotuning.ino
+++ b/TestPIDAutotuning.ino
@@ -1,23 +1,14 @@
-#include "forno.h"
+#include "Forno.h"
 
-
-Forno mioForno (0.01,0.002);
+Forno forno(0.01, 0.002);
 
 //   ******* SETUP *******
-void setup()
-{
-
+void setup() {
 
 }
 
 //   ******* LOOP *******
-void loop()
-{
-    mioForno.aggiorna();
-
-    double temperaturaAttuale = mioForno.ottieniTemperatura();
-
-    
-    Serial.println("La temperatura del forno è " + String(temperaturaAttuale) + " °C");
+void loop() {
+    forno.aggiorna();
+    Serial.println("La temperatura del forno è " + String(forno.temperatura()) + " °C");
 }
-


### PR DESCRIPTION
1 - c++ ti lascia settare i campi che non dipendono da variabili nel costruttore direttamente nella definizione della classe
2 - e' uso dichiarare i campi privati con un nome preceduto da "_" oppure da "m_";
3 - lascia l'enum interno alla classe, il cliente non ha bisogno di usarlo
